### PR TITLE
fix(ci): use npm workspace scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,19 +20,17 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.19.5
-          cache: 'pnpm'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9.0.0
-          run_install: true
+      - name: Install dependencies
+        run: npm ci
 
       - name: Lint
-        run: pnpm lint
+        run: npm run lint
 
       - name: Test
-        run: pnpm test
+        run: npm run test
 
       - name: Build
-        run: pnpm build
+        run: npm run build


### PR DESCRIPTION
## Summary
- switch the CI workflow from pnpm to npm tooling to match the repo
- install dependencies with npm ci and reuse workspace scripts for lint, test, and build

## Testing
- npm run lint
- npm run test
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cee39b954c832f91f5660f0d75e400