### PR TITLE
Fix Pages workflow for npm static export

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,14 +24,12 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ vars.NODE_VERSION || 20 }}
-          cache: 'pnpm'
+          node-version: ${{ vars.NODE_VERSION || 20.19.5 }}
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: ${{ vars.PNPM_VERSION || 9 }}
-          run_install: true
+      - name: Install dependencies
+        run: npm ci
 
       - name: Verify no Firebase admin JSON leaked
         run: |
@@ -47,9 +45,7 @@ jobs:
           NEXT_PUBLIC_SUPABASE_URL: ${{ vars.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || vars.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
         run: |
-          cd apps/web
-          pnpm build
-          cd ..
+          npm run build --workspace @thecueroom/web
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -12,8 +12,6 @@ export const metadata: Metadata = {
   metadataBase: new URL('https://thecueroom.local'),
 };
 
-export const dynamic = 'force-dynamic';
-
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en" className={`${inter.variable} ${sourceCodePro.variable}`} suppressHydrationWarning>

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const config = {
-  output: 'standalone',
+  output: 'export',
   reactStrictMode: true
 };
 


### PR DESCRIPTION
## Summary
- switch the GitHub Pages workflow to the npm toolchain and reuse the workspace build script
- enable static exports for the web app by setting `output: 'export'`
- drop the forced dynamic rendering flag so the layout can be pre-rendered for Pages

## Testing
- npm run lint
- npm run test
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cee6b5ef60832faaa1e486f63c89d0