### PR TITLE
Fix GitHub Pages Node version fallback

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ vars.NODE_VERSION || 20.19.5 }}
+          node-version: ${{ vars.NODE_VERSION || '20.19.5' }}
           cache: 'npm'
           cache-dependency-path: package-lock.json
 


### PR DESCRIPTION
## Summary
- wrap the GitHub Pages workflow node-version fallback in quotes so the expression parses

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ceea33913c832fa7ea449bd0fcbd6e