### PR TITLE
Skip Pages deployment when Pages is disabled

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,6 +17,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      pages_enabled: ${{ steps.pages-status.outputs.enabled }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -47,15 +49,40 @@ jobs:
         run: |
           npm run build --workspace @thecueroom/web
 
+      - name: Check GitHub Pages status
+        id: pages-status
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const core = require('@actions/core');
+            try {
+              await github.rest.repos.getPages({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              });
+              core.info('GitHub Pages is enabled for this repository.');
+              core.setOutput('enabled', 'true');
+            } catch (error) {
+              if (error.status === 404) {
+                core.warning('GitHub Pages is not enabled for this repository. Skipping deployment steps.');
+                core.setOutput('enabled', 'false');
+              } else {
+                throw error;
+              }
+            }
+
       - name: Setup Pages
+        if: steps.pages-status.outputs.enabled == 'true'
         uses: actions/configure-pages@v5
 
       - name: Upload artifact
+        if: steps.pages-status.outputs.enabled == 'true'
         uses: actions/upload-pages-artifact@v3
         with:
           path: "apps/web/out"
 
   deploy:
+    if: needs.build.outputs.pages_enabled == 'true'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary
- check whether GitHub Pages is enabled before configuring deployment
- skip configure/upload/deploy steps when Pages is disabled to keep the workflow green

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ceebbd1310832f8ede15991d0d1645