### PR TITLE
Fix GitHub Pages script core redeclaration

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -54,7 +54,6 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const core = require('@actions/core');
             try {
               await github.rest.repos.getPages({
                 owner: context.repo.owner,


### PR DESCRIPTION
## Summary
- use the core helper provided by actions/github-script to avoid redeclaration errors during the GitHub Pages status check

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1150c1390832fb491f17e8dc70a25