### PR TITLE
Fix Deno lint errors by importing process

### DIFF
--- a/apps/mobile/jest.setup.ts
+++ b/apps/mobile/jest.setup.ts
@@ -1,5 +1,6 @@
 import '@testing-library/jest-native/extend-expect';
 import 'react-native-gesture-handler/jestSetup';
+import process from 'node:process';
 
 process.env.EXPO_PUBLIC_SUPABASE_URL =
   process.env.EXPO_PUBLIC_SUPABASE_URL ?? 'https://example-project.supabase.co';

--- a/apps/mobile/src/lib/supabase.ts
+++ b/apps/mobile/src/lib/supabase.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
+import process from 'node:process';
 
 const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL;
 const supabaseAnonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;


### PR DESCRIPTION
## Summary
- import the Node process global in the mobile Jest setup used by tests
- explicitly import process in the Supabase client helper to satisfy deno lint

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1215a2554832fba6fe9d78bc96036