### PR TITLE
fix: add explicit extension for feed screen test

### DIFF
--- a/apps/mobile/__tests__/Feed.test.tsx
+++ b/apps/mobile/__tests__/Feed.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react-native';
-import { FeedScreen } from '../src/screens/Feed';
+import { FeedScreen } from '../src/screens/Feed.tsx';
 
 describe('FeedScreen', () => {
   it('shows the feed header', () => {


### PR DESCRIPTION
## Summary
- include the `.tsx` extension in the FeedScreen test import so Deno can resolve the file

## Testing
- npm run lint
- npm run test
- npm --workspace @thecueroom/mobile test -- --runInBand
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d12fb18cb0832f81645b321cb3dfdd